### PR TITLE
Fixing site_names -> sites

### DIFF
--- a/telescope/selector.py
+++ b/telescope/selector.py
@@ -76,7 +76,7 @@ class MultiSelector(object):
        how to translate the IP address information.
      client_providers: (list) List of string names of providers in the child
        Selectors.
-     site_names: (list) List of M-Lab sites in the child Selectors..
+     sites: (list) List of M-Lab sites in the child Selectors..
   """
   def __init__(self):
     self.start_times = None
@@ -340,8 +340,8 @@ class MultiSelectorJsonEncoder(json.JSONEncoder):
         'start_times': self._encode_start_times(selector.start_times)
         }
 
-    if selector.site_names != [None]:
-        base_selector['sites'] = selector.site_names
+    if selector.sites != [None]:
+        base_selector['sites'] = selector.sites
     if selector.client_countries != [None]:
         base_selector['client_countries'] = selector.client_countries
     if selector.client_providers != [None]:

--- a/tests/test_selector.py
+++ b/tests/test_selector.py
@@ -394,7 +394,7 @@ class MultiSelectorJsonEncoderTest(unittest.TestCase):
     s = selector.MultiSelector()
     s.start_times = [datetime.datetime(2015, 4, 2, 10, 27, 34)]
     s.duration = 45
-    s.site_names = ['mia01']
+    s.sites = ['mia01']
     s.client_providers = ['twc']
     s.client_countries = ['us']
     s.metrics = ['upload_throughput']
@@ -428,7 +428,7 @@ class MultiSelectorJsonEncoderTest(unittest.TestCase):
         datetime.datetime(2015, 4, 15, 0, 0, 0),
         ]
     s.duration = 7
-    s.site_names = ['iad01', 'lga06', 'mia01', 'nuq03']
+    s.sites = ['iad01', 'lga06', 'mia01', 'nuq03']
     s.client_providers = ['comcast', 'twc', 'verizon']
     s.metrics = ['download_throughput', 'upload_throughput', 'minimum_rtt']
     s.ip_translation_spec = (iptranslation.IPTranslationStrategySpec(


### PR DESCRIPTION
A while ago we changed the term "site_names" to "sites" but missed a few
spots. This fixes it so that it's always "sites" and never "site_names."