### PR TITLE
Adding a pre-commit hook to check formatting issues.

### DIFF
--- a/dev/pre-commit.sh
+++ b/dev/pre-commit.sh
@@ -15,7 +15,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Block the commit if it breaks unit tests.
-if ! python -m unittest discover; then
-    exit -1
-fi
+# Block the commit if it breaks unit tests or formatting
+python -m unittest discover && yapf --diff --recursive --style google ./


### PR DESCRIPTION
You can configure your repo to use this hook with the following command:
```
ln -s -f ../../dev/pre-commit.sh .git/hooks/pre-commit
```

Also documented in the [wiki](https://github.com/m-lab/telescope/wiki/Running-unit-tests)