### PR TITLE
Fixing divide by zero error in average_rtt query

### DIFF
--- a/telescope/query.py
+++ b/telescope/query.py
@@ -85,6 +85,12 @@ def _create_test_validity_conditional(metric):
             ('(web100_log_entry.snap.SndLimTimeRwin +\n\t'
              '\tweb100_log_entry.snap.SndLimTimeCwnd +\n\t'
              '\tweb100_log_entry.snap.SndLimTimeSnd) < %u') % MAX_DURATION)
+
+        # Some rows in the NDT dataset strangely have CountRTT as 0 but
+        # HCThruOctetsAcked > 0. Add a clause to prevent divide by zero errors
+        # in the query.
+        if metric == 'average_rtt':
+            conditions.append('web100_log_entry.snap.CountRTT > 0')
     else:
         # Must receive at least the minimum number of bytes.
         conditions.append(

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -288,7 +288,7 @@ WHERE
   AND (web100_log_entry.snap.SndLimTimeRwin +
        web100_log_entry.snap.SndLimTimeCwnd +
        web100_log_entry.snap.SndLimTimeSnd) < 3600000000
-  AND web100_log_entry.snap.CountRTT > 0
+  AND web100_log_entry.snap.CountRTT > 10
   AND ((web100_log_entry.log_time >= 1388534400) AND (web100_log_entry.log_time < 1391212800))
   AND (web100_log_entry.connection_spec.local_ip = '1.1.1.1' OR
        web100_log_entry.connection_spec.local_ip = '2.2.2.2')
@@ -331,6 +331,7 @@ WHERE
   AND (web100_log_entry.snap.SndLimTimeRwin +
        web100_log_entry.snap.SndLimTimeCwnd +
        web100_log_entry.snap.SndLimTimeSnd) < 3600000000
+  AND web100_log_entry.snap.CountRTT > 10
   AND ((web100_log_entry.log_time >= 1388534400) AND (web100_log_entry.log_time < 1391212800))
   AND (web100_log_entry.connection_spec.local_ip = '1.1.1.1' OR
        web100_log_entry.connection_spec.local_ip = '2.2.2.2')

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -288,6 +288,7 @@ WHERE
   AND (web100_log_entry.snap.SndLimTimeRwin +
        web100_log_entry.snap.SndLimTimeCwnd +
        web100_log_entry.snap.SndLimTimeSnd) < 3600000000
+  AND web100_log_entry.snap.CountRTT > 0
   AND ((web100_log_entry.log_time >= 1388534400) AND (web100_log_entry.log_time < 1391212800))
   AND (web100_log_entry.connection_spec.local_ip = '1.1.1.1' OR
        web100_log_entry.connection_spec.local_ip = '2.2.2.2')


### PR DESCRIPTION
There are rows in BigQuery that strangely have `CountRTT` as 0 even though `HCThruOctetsAcked` > 0 (which seems invalid to me, but I'm maybe missing something). The SQL generation assumed that an explicit check on `CountRTT` > 0 was unnecessary because we were already checking that `HCThruOctetsAcked` >= 8192, but it looks like we need to check both fields.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/m-lab/telescope/75)
<!-- Reviewable:end -->

Update: Talked to Matt Mathis, `CountRTT` as 0 and `HCThruOctetsAcked` > 0 is a valid NDT result:
> CountRTT is the count of RTT measurements and is only intended to be used with SumRTT to compute a true mean RTT.   Since RTT measurements can be spoiled, for example if the segment being timed is retransmitted, there may be fewer CountRTTs than actual RTTs.   Completing a (short) connection with zero measurements is not very unusual.