### PR TITLE
Preventing telescope from swallowing fatal exceptions

### DIFF
--- a/telescope/telescope.py
+++ b/telescope/telescope.py
@@ -475,18 +475,10 @@ def main(args):
         data_selector.ip_translation_spec.params['maxmind_dir'] = (
             args.maxminddir)
 
-        try:
-            ip_translator = ip_translator_factory.create(
-                data_selector.ip_translation_spec)
-            bq_query_string = generate_query(
-                data_selector, ip_translator, mlab_site_resolver)
-        except MLabServerResolutionFailed as caught_error:
-            logger.error('Failed to resolve M-Lab servers: %s', caught_error)
-            # This error is fatal, so bail out here.
-            return None
-        except Exception as caught_error:
-            logger.error('Failed to generate queries: %s', caught_error)
-            continue
+        ip_translator = ip_translator_factory.create(
+            data_selector.ip_translation_spec)
+        bq_query_string = generate_query(
+            data_selector, ip_translator, mlab_site_resolver)
 
         if args.savequery:
             bigquery_filepath = utils.build_filename(


### PR DESCRIPTION
Currently main() puts the call to generate_query within a try/except and
swallows the exception if it encounters a fatal exception. This is bad because
it causes telescope to exit with a successful error code even if it failed,
which confuses tools that rely on Telescope's exit code.

This fixes the issue by just letting the exceptions bubble out on their own.
They don't need extra logging because the exceptions themselves will describe
the failure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/telescope/101)
<!-- Reviewable:end -->
