### PR TITLE
Refactor metrics to CSV conversion

### DIFF
--- a/telescope/result_csv.py
+++ b/telescope/result_csv.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2014 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Provides functions to convert NDT results to CSV format."""
+
+import csv
+import io
+
+
+def metrics_to_csv(metrics):
+    """Converts a list of result metrics to CSV format.
+
+    Args:
+        metrics: (list) A list of dictionaries containing the values
+          of NDT metrics, such as:
+
+          [{'timestamp': 1466792556, 'average_rtt': 20.3},
+           {'timestamp': 1466792559, 'average_rtt': 25.2},
+           {'timestamp': 1466792553, 'average_rtt': 21.9}]
+
+    Returns:
+        The specified result list as a headerless, CSV-formatted string, such
+        as:
+
+          1466792556,20.3
+          1466792559,25.2
+          1466792553,21.9
+
+        The rows are not in sorted order, but the timestamp field is always the
+        first column.
+    """
+    if not metrics:
+        return ''
+    # Ensure that timestamp is the first column of the CSV.
+    fieldnames_ordered = metrics[0].keys()
+    fieldnames_ordered.remove('timestamp')
+    fieldnames_ordered.insert(0, 'timestamp')
+
+    output_buffer = io.BytesIO()
+    data_file_csv = csv.DictWriter(output_buffer, fieldnames=fieldnames_ordered)
+    data_file_csv.writerows(metrics)
+    return output_buffer.getvalue()

--- a/telescope/result_csv.py
+++ b/telescope/result_csv.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: UTF-8 -*-
 #
-# Copyright 2014 Measurement Lab
+# Copyright 2016 Measurement Lab
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/telescope/telescope.py
+++ b/telescope/telescope.py
@@ -17,7 +17,6 @@
 
 import argparse
 import copy
-import csv
 import datetime
 import logging
 import os
@@ -30,6 +29,7 @@ import external
 import iptranslation
 import mlab
 import query
+import result_csv
 import selector
 import utils
 
@@ -160,28 +160,14 @@ def write_metric_calculations_to_file(data_filepath,
         data_filepath: (str) File path to which to write data.
         metric_calculations: (list) A list of dictionaries containing the values
           of retrieved metrics.
-        should_write_header: (bool) Indicates whether the output file should
-          contain a header line to identify each column of data.
 
     Returns:
       (bool) True if the file was written successfully.
     """
     logger = logging.getLogger('telescope')
-    fieldnames_ordered = metric_calculations[0].keys()
-    if fieldnames_ordered[0] != 'timestamp':
-        fieldnames_ordered.reverse()
     try:
         with open(data_filepath, 'w') as data_file_raw:
-            if metric_calculations:
-                data_file_csv = csv.DictWriter(
-                    data_file_raw,
-                    fieldnames=fieldnames_ordered,
-                    delimiter=',',
-                    quotechar='"',
-                    quoting=csv.QUOTE_MINIMAL)
-                if should_write_header:
-                    data_file_csv.writeheader()
-                data_file_csv.writerows(metric_calculations)
+            data_file_raw.write(result_csv.metrics_to_csv(metric_calculations))
         return True
     except IOError as caught_error:
         if caught_error.errno == 24:
@@ -189,7 +175,7 @@ def write_metric_calculations_to_file(data_filepath,
                 'When writing raw output, caught %s, trying again shortly.',
                 caught_error)
             write_metric_calculations_to_file(
-                data_filepath, metric_calculations, should_write_header)
+                data_filepath, metric_calculations)
             time.sleep(20)
         else:
             logger.error('When writing raw output, caught %s, cannot move on.',

--- a/tests/test_result_csv.py
+++ b/tests/test_result_csv.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+#
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import unittest
+
+from telescope import result_csv
+
+
+class ResultCsvTest(unittest.TestCase):
+
+    def test_metrics_to_csv_returns_empty_string_when_given_empty_list(self):
+        self.assertEqual('', result_csv.metrics_to_csv([]))
+
+    def test_metrics_to_csv_processes_single_element_list_correctly(self):
+        """Single element lists should create one CSV line in correct order."""
+        self.assertEqual('123456,54.6\r\n', result_csv.metrics_to_csv(
+            [{'timestamp': 123456,
+              'download_mbps': 54.6}]))
+        self.assertEqual('123456,54.6\r\n', result_csv.metrics_to_csv(
+            [{'timestamp': 123456,
+              'upload_mbps': 54.6}]))
+        self.assertEqual('123456,54.6\r\n', result_csv.metrics_to_csv(
+            [{'timestamp': 123456,
+              'average_rtt': 54.6}]))
+        self.assertEqual('123456,54.6\r\n', result_csv.metrics_to_csv(
+            [{'timestamp': 123456,
+              'minimum_rtt': 54.6}]))
+        self.assertEqual('123456,54.6\r\n', result_csv.metrics_to_csv(
+            [{'timestamp': 123456,
+              'packet_retransmit_rate': 54.6}]))
+
+    def test_metrics_to_csv_processes_three_element_list_correctly(self):
+        metrics_list = [
+            {'timestamp': 123456, 'download_mbps': 54.6},
+            {'timestamp': 234567, 'download_mbps': 19.9},
+            {'timestamp': 345678, 'download_mbps': 23.5}
+        ]  # yapf: disable
+        csv_expected = ('123456,54.6\r\n'
+                        '234567,19.9\r\n'
+                        '345678,23.5\r\n')  # yapf: disable
+        csv_actual = result_csv.metrics_to_csv(metrics_list)
+        self.assertMultiLineEqual(csv_expected, csv_actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_result_csv.py
+++ b/tests/test_result_csv.py
@@ -18,6 +18,8 @@
 from __future__ import absolute_import
 import unittest
 
+import mock
+
 from telescope import result_csv
 
 
@@ -43,6 +45,20 @@ class ResultCsvTest(unittest.TestCase):
         self.assertEqual('123456,54.6\r\n', result_csv.metrics_to_csv(
             [{'timestamp': 123456,
               'packet_retransmit_rate': 54.6}]))
+
+    def test_metrics_to_csv_always_makes_timestamp_first_column(self):
+
+        def mock_get(key, _):
+            row = {'timestamp': 123456, 'download_mbps': 54.6}
+            return row[key]
+
+        mock_row = mock.MagicMock()
+        # metrics_to_csv should make timestamp the first column, even if it
+        # recevies the row keys in a different order.
+        mock_row.keys.return_value = ['download_mbps', 'timestamp']
+        mock_row.get.side_effect = mock_get
+        self.assertEqual('123456,54.6\r\n',
+                         result_csv.metrics_to_csv([mock_row]))
 
     def test_metrics_to_csv_processes_three_element_list_correctly(self):
         metrics_list = [


### PR DESCRIPTION
This refactors the CSV conversion logic in telescope.py to a separate module
and adds a unit test for it.

Additionally, this fixes a bug in the CSV processing where Telescope would
throw an exception if it tried to write results for a query that had zero
rows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/telescope/105)
<!-- Reviewable:end -->
